### PR TITLE
docs: add README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme Project Management documentation. This folder centralizes our operational processes, artifacts, and templates so teams can consistently plan, execute, and improve projects. The docs emphasize clear ownership (Project Manager and Product Lead), measurable success criteria captured in a Project One‑pager, and iterative delivery with short, testable increments. We prioritize customer value, data‑informed tradeoffs, and psychological safety to encourage learning and continuous improvement.
+
+Our workflows use a project board (Backlog → Ready → In Progress → In Review → QA → Done) and a disciplined pull request process: small PRs, linked issues and acceptance criteria, automated CI checks and security scans, and explicit approvals before merging. Planning converts approved initiatives into prioritized backlogs with acceptance criteria and estimates, and releases follow a checklist that includes staging smoke tests, rollback plans, and post‑deploy verification. Regular cadence items—daily standups, weekly PM+PdM syncs, demos, and monthly stakeholder updates—keep communication predictable.
+
+Roles and responsibilities are defined in the Roles & Personas doc: Product Managers define outcomes and prioritize, Project Managers coordinate delivery and risks, Developers build and test, and QA validates acceptance criteria. Risk and dependency management is captured in a Risk Register that is updated at least weekly; escalation paths run from team-level triage to PM → Product Lead → Sponsor (with a separate security incident runbook when needed).
+
+For quality assurance, we combine automated unit/integration tests, security scanning in CI, end‑to‑end smoke tests for critical flows before release, and targeted manual QA where required. Continuous improvement is enforced through retrospectives that surface 2–3 prioritized action items and track them back into the backlog. Use the links below to jump to specific process documents.
+
+Process Documents
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)


### PR DESCRIPTION
This PR adds docs/README.md, a central entry point for OctoAcme project management documentation. It includes a concise overview of workflows, roles, communication cadence, and quality practices, and links to the full process docs in docs/.